### PR TITLE
Allow LDAP Modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,18 @@ The `Group` class supports the following finder methods:
 * `Cratus::Group.all` returns an `Array<Cratus::Group>` of all groups scoped at or below the `group_basedn`.
 * `Cratus::Group.new('name')` creates a new instance populated with details from LDAP (or raises `Cratus::Exceptions::FailedLDAPSearch` if the group can't be found).
 
-Instances of `Group` have the following attributes and methods:
+Instances of `Group` have the following read-only attributes and methods:
 
 * `#members` provides an `Array<Cratus::User>` of all users that are a member of the group. It does this recursively, so it supports nested groups.
 * `#member_groups` provides an `Array<Cratus::Group>` of all groups that are a member of the group. It does this recursively, so it supports nested groups.
 * `#member_of` provides an `Array<Cratus::Group>` of all groups that this group is a member of. It does this recursively, so it supports nested groups.
 * `#dn` returns the distinguished name (dn) of the LDAP object
 * `#description` returns the configurable LDAP "description" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
+
+Instances of `Group` have the following methods that can change the underlying LDAP object:
+
+* `#add_user(user)` allows adding individual LDAP users to a group. This method takes as input an instance of `Cratus::User`. It is idempotent and will add users as direct members of the group unless the user is already a member (directly or indirectly).
+* `#remove_user(user)` allows removing individual LDAP users from a group. This method takes as input an instance of `Cratus::User`. It is idempotent and will remove users that are direct members of the group.
 
 The `Group` class also implements [Comparable](https://ruby-doc.org/core-2.3.0/Comparable.html), so it supports common comparison methods, most notably `==`.
 
@@ -120,7 +125,7 @@ The `User` class supports the following finder methods:
 * `Cratus::User.all` returns an `Array` of all users scoped at or below the `user_basedn`.
 * `Cratus::User.new('name')` creates a new instance populated with details from LDAP (or raises `Cratus::Exceptions::FailedLDAPSearch` if the group can't be found).
 
-Instances of `User` have the following attributes and methods:
+Instances of `User` have the following read-only attributes and methods:
 
 * `#department` returns the LDAP "department" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
 * `#email` returns the configurable LDAP "mail" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
@@ -130,6 +135,11 @@ Instances of `User` have the following attributes and methods:
 * `#locked?` returns `true` or `false` based on `#lockouttime` and `#lockoutduration`.
 * `#member_of` provides an `Array<Cratus::Group>` of all groups that this user is a member of. It does this recursively, so it supports nested groups.
 * `#dn` returns the distinguished name (dn) of the LDAP object
+
+Instances of `User` have the following methods that can change the underlying LDAP object:
+
+* `#add_to_group(group)` allows adding an LDAP user to a group. This method takes as input an instance of `Cratus::Group`. It is idempotent and will add users as direct members of the group unless the user is already a member (directly or indirectly).
+* `#remove_from_group(group)` allows removing an LDAP user from a group. This method takes as input an instance of `Cratus::Group`. It is idempotent and will remove the user if it is a direct members of the group.
 
 The `User` class also implements [Comparable](https://ruby-doc.org/core-2.3.0/Comparable.html), so it supports common comparison methods, most notably `==`.
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new(:rubocop)
 YARD::Rake::YardocTask.new
 
-task default: %i(spec rubocop yard)
+task default: %i[spec rubocop yard]

--- a/lib/cratus/group.rb
+++ b/lib/cratus/group.rb
@@ -61,9 +61,10 @@ module Cratus
 
     # Add a User to the group
     def add_user(user)
-      raise 'InvalidUser' unless user.is_a?(User)
-      return true if members.include?(user)
+      raise 'InvalidUser' unless user.respond_to?(:dn)
       direct_members = @raw_ldap_data[Cratus.config.group_member_attribute]
+      return true if direct_members.include?(user.dn)
+
       direct_members << user.dn
       Cratus::LDAP.replace_attribute(
         dn,
@@ -74,9 +75,10 @@ module Cratus
 
     # Remove a User from the group
     def remove_user(user)
-      raise 'InvalidUser' unless user.is_a?(User)
-      return true unless members.include?(user)
+      raise 'InvalidUser' unless user.respond_to?(:dn)
       direct_members = @raw_ldap_data[Cratus.config.group_member_attribute]
+      return true unless direct_members.include?(user.dn)
+
       direct_members.delete(user.dn)
       Cratus::LDAP.replace_attribute(
         dn,

--- a/lib/cratus/group.rb
+++ b/lib/cratus/group.rb
@@ -59,6 +59,32 @@ module Cratus
       @raw_ldap_data[Cratus.config.group_description_attribute].last
     end
 
+    # Add a User to the group
+    def add_user(user)
+      raise 'InvalidUser' unless user.is_a?(User)
+      return true if members.include?(user)
+      direct_members = @raw_ldap_data[Cratus.config.group_member_attribute]
+      direct_members << user.dn
+      Cratus::LDAP.replace_attribute(
+        dn,
+        Cratus.config.group_member_attribute,
+        direct_members.uniq
+      )
+    end
+
+    # Remove a User from the group
+    def remove_user(user)
+      raise 'InvalidUser' unless user.is_a?(User)
+      return true unless members.include?(user)
+      direct_members = @raw_ldap_data[Cratus.config.group_member_attribute]
+      direct_members.delete(user.dn)
+      Cratus::LDAP.replace_attribute(
+        dn,
+        Cratus.config.group_member_attribute,
+        direct_members.uniq
+      )
+    end
+
     # All the LDAP Groups
     def self.all
       filter = "(#{ldap_dn_attribute}=*)"

--- a/lib/cratus/ldap.rb
+++ b/lib/cratus/ldap.rb
@@ -95,7 +95,7 @@ module Cratus
     def self.validate_connection_options(options)
       raise 'Invalid Options' unless options.respond_to?(:key?)
 
-      %i(host port basedn username password).each do |key|
+      %i[host port basedn username password].each do |key|
         raise "Missing Option: #{key}" unless options.key?(key)
       end
     end

--- a/lib/cratus/ldap.rb
+++ b/lib/cratus/ldap.rb
@@ -61,6 +61,15 @@ module Cratus
       results.nil? ? raise(Exceptions::FailedLDAPSearch) : results.compact
     end
 
+    # Modify an LDAP object's attribute
+    def self.replace_attribute(dn, attribute, values)
+      validate_ldap_connection
+      validate_ldap_bound
+      validate_attribute_values(values)
+
+      connection.replace_attribute(dn, attribute, values)
+    end
+
     # Validation Methods
 
     def self.validate_ldap_bound
@@ -77,6 +86,10 @@ module Cratus
       [:basedn].each do |key|
         raise "Missing Option: #{key}" unless options.key?(key)
       end
+    end
+
+    def self.validate_attribute_values(values)
+      raise 'Values Must Be Array' unless values.is_a?(Array)
     end
 
     def self.validate_connection_options(options)

--- a/lib/cratus/user.rb
+++ b/lib/cratus/user.rb
@@ -16,14 +16,14 @@ module Cratus
 
     # Add a user to a group
     def add_to_group(group)
-      raise 'InvalidGroup' unless group.is_a?(Group)
+      raise 'InvalidGroup' unless group.respond_to?(:add_user)
       # just be lazy and hand off to the group to do the work...
       group.add_user(self)
     end
 
     # Remove a user from a group
     def remove_from_group(group)
-      raise 'InvalidGroup' unless group.is_a?(Group)
+      raise 'InvalidGroup' unless group.respond_to?(:remove_user)
       # just be lazy and hand off to the group to do the work...
       group.remove_user(self)
     end

--- a/lib/cratus/user.rb
+++ b/lib/cratus/user.rb
@@ -14,6 +14,20 @@ module Cratus
       ).last
     end
 
+    # Add a user to a group
+    def add_to_group(group)
+      raise 'InvalidGroup' unless group.is_a?(Group)
+      # just be lazy and hand off to the group to do the work...
+      group.add_user(self)
+    end
+
+    # Remove a user from a group
+    def remove_from_group(group)
+      raise 'InvalidGroup' unless group.is_a?(Group)
+      # just be lazy and hand off to the group to do the work...
+      group.remove_user(self)
+    end
+
     def department
       @raw_ldap_data[Cratus.config.user_department_attribute].last
     end

--- a/lib/cratus/version.rb
+++ b/lib/cratus/version.rb
@@ -2,8 +2,8 @@
 module Cratus
   def self.version
     major = 0 # Breaking, incompatible releases
-    minor = 3 # Compatible, but new features
-    patch = 9 # Fixes to existing features
+    minor = 4 # Compatible, but new features
+    patch = 0 # Fixes to existing features
     [major, minor, patch].map(&:to_s).join('.')
   end
 end

--- a/spec/cratus/ldap_spec.rb
+++ b/spec/cratus/ldap_spec.rb
@@ -10,13 +10,13 @@ describe Cratus::LDAP do
       base: 'ou=users,dc=example,dc=com',
       filter: '(uid=foo*)',
       scope: 2,
-      attributes: %w(uid displayname department samaccountname lockouttime)
+      attributes: %w[uid displayname department samaccountname lockouttime]
     }
   end
 
   let(:cratus_search) do
     {
-      attrs: %i(uid displayname department samaccountname lockouttime),
+      attrs: %i[uid displayname department samaccountname lockouttime],
       basedn: 'ou=users,dc=example,dc=com'
     }
   end

--- a/spec/cratus/ldap_spec.rb
+++ b/spec/cratus/ldap_spec.rb
@@ -14,6 +14,14 @@ describe Cratus::LDAP do
     }
   end
 
+  let(:netldap_args) do
+    [
+      'uid=foobar,ou=users,dc=example,dc=com',
+      :department,
+      ['Test']
+    ]
+  end
+
   let(:cratus_search) do
     {
       attrs: %i[uid displayname department samaccountname lockouttime],
@@ -38,6 +46,8 @@ describe Cratus::LDAP do
     ldap = instance_double('Net::LDAP', bind: true)
     allow(ldap).to receive(:search).and_return(nil)
     allow(ldap).to receive(:search).with(netldap_search).and_return(search_result)
+    allow(ldap).to receive(:replace_attribute).and_return(false)
+    allow(ldap).to receive(:replace_attribute).with(*netldap_args).and_return(true)
     ldap
   end
 
@@ -57,6 +67,14 @@ describe Cratus::LDAP do
     allow(Net::LDAP).to receive(:new).and_return(ldap_instance)
     expect(subject.connect).to eq(true)
     expect(subject.search('(uid=foo*)', cratus_search)).to eq(search_result)
+    # Put things back how we found them...
+    subject.instance_variable_set(:'@ldap_connection', nil)
+  end
+
+  it 'allows modifying LDAP attributes' do
+    allow(Net::LDAP).to receive(:new).and_return(ldap_instance)
+    expect(subject.connect).to eq(true)
+    expect(subject.replace_attribute(*netldap_args)).to eq(true)
     # Put things back how we found them...
     subject.instance_variable_set(:'@ldap_connection', nil)
   end


### PR DESCRIPTION
Quick and simple LDAP attribute replacement à la `LDAP.replace_attribute()`.

Added helpful methods to `User` and `Group` for managing group memberships. This could easily be extended for other LDAP attributes we care about modifying.