### PR TITLE
Added unlock, disable, and enable to `User`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Cratus supports configuration settings, controlled via the following keys with t
         user_dn_attribute: :samaccountname,
         user_objectclass: :user,
         user_basedn: 'ou=users,dc=example,dc=com',
+        user_account_control_attribute: :userAccountControl,
         user_department_attribute: :department,
         user_lockout_attribute: :lockouttime,
         user_mail_attribute: :mail,
@@ -128,7 +129,9 @@ The `User` class supports the following finder methods:
 Instances of `User` have the following read-only attributes and methods:
 
 * `#department` returns the LDAP "department" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
+* `#disabled?` returns `true` of `false` to indicate whether the User is fully disabled in LDAP.
 * `#email` returns the configurable LDAP "mail" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
+* `#enabled?` returns `true` of `false` to indicate whether the User is fully enabled in LDAP.
 * `#fullname` returns the configurable LDAP "displayName" attribute as stored in LDAP if it exists. Otherwise it returns `nil`.
 * `#lockouttime` returns the configurable LDAP "lockouttime" attribute as stored in LDAP if it exists. Otherwise it returns `0`.
 * `#lockoutduration` queries the Active Directory basedn for the `lockoutDuration` attribute for use in calculations with `#lockouttime`.
@@ -140,6 +143,9 @@ Instances of `User` have the following methods that can change the underlying LD
 
 * `#add_to_group(group)` allows adding an LDAP user to a group. This method takes as input an instance of `Cratus::Group`. It is idempotent and will add users as direct members of the group unless the user is already a member (directly or indirectly).
 * `#remove_from_group(group)` allows removing an LDAP user from a group. This method takes as input an instance of `Cratus::Group`. It is idempotent and will remove the user if it is a direct members of the group.
+* `#disable` changes the User Account Control (usually `userAccountControl`) attribute to `514`, signifying that logins are not allowed.
+* `#enable` changes the User Account Control (usually `userAccountControl`) attribute to `512`, signifying that logins are allowed.
+* `#unlock` changes the `lockouttime` atrribute to `0`, signifying that the account is not locked out.
 
 The `User` class also implements [Comparable](https://ruby-doc.org/core-2.3.0/Comparable.html), so it supports common comparison methods, most notably `==`.
 

--- a/lib/cratus/config.rb
+++ b/lib/cratus/config.rb
@@ -14,6 +14,7 @@ module Cratus
         user_dn_attribute: :samaccountname,
         user_objectclass: :user,
         user_basedn: 'ou=users,dc=example,dc=com',
+        user_account_control_attribute: :userAccountControl,
         user_department_attribute: :department,
         user_lockout_attribute: :lockouttime,
         user_mail_attribute: :mail,

--- a/lib/cratus/user.rb
+++ b/lib/cratus/user.rb
@@ -7,11 +7,7 @@ module Cratus
     def initialize(username)
       @username = username
       @search_base = self.class.ldap_search_base
-      @raw_ldap_data = Cratus::LDAP.search(
-        "(#{self.class.ldap_dn_attribute}=#{@username})",
-        basedn: @search_base,
-        attrs: self.class.ldap_return_attributes
-      ).last
+      refresh
     end
 
     # Add a user to a group
@@ -38,8 +34,9 @@ module Cratus
         Cratus::LDAP.replace_attribute(
           dn,
           Cratus.config.user_account_control_attribute,
-          '514'
+          ['514']
         )
+        refresh
       else
         true
       end
@@ -64,8 +61,9 @@ module Cratus
         Cratus::LDAP.replace_attribute(
           dn,
           Cratus.config.user_account_control_attribute,
-          '512'
+          ['512']
         )
+        refresh
       else
         true
       end
@@ -126,6 +124,14 @@ module Cratus
 
     alias groups member_of
 
+    def refresh
+      @raw_ldap_data = Cratus::LDAP.search(
+        "(#{self.class.ldap_dn_attribute}=#{@username})",
+        basedn: @search_base,
+        attrs: self.class.ldap_return_attributes
+      ).last
+    end
+
     # Unlocks a user
     # @return `true` on success (or if user is already unlocked)
     # @return `false` when the account is disabled (unlocking not permitted)
@@ -134,8 +140,9 @@ module Cratus
         Cratus::LDAP.replace_attribute(
           dn,
           Cratus.config.user_lockout_attribute,
-          '0'
+          ['0']
         )
+        refresh
       elsif disabled?
         false
       else
@@ -174,7 +181,8 @@ module Cratus
         Cratus.config.user_mail_attribute.to_s,
         Cratus.config.user_displayname_attribute.to_s,
         Cratus.config.user_memberof_attribute.to_s,
-        Cratus.config.user_lockout_attribute.to_s
+        Cratus.config.user_lockout_attribute.to_s,
+        Cratus.config.user_account_control_attribute.to_s
       ]
     end
 

--- a/lib/cratus/version.rb
+++ b/lib/cratus/version.rb
@@ -2,7 +2,7 @@
 module Cratus
   def self.version
     major = 0 # Breaking, incompatible releases
-    minor = 4 # Compatible, but new features
+    minor = 5 # Compatible, but new features
     patch = 0 # Fixes to existing features
     [major, minor, patch].map(&:to_s).join('.')
   end

--- a/spec/cratus/user_spec.rb
+++ b/spec/cratus/user_spec.rb
@@ -18,7 +18,8 @@ describe Cratus::User do
         Cratus.config.user_mail_attribute.to_s,
         Cratus.config.user_displayname_attribute.to_s,
         Cratus.config.user_memberof_attribute.to_s,
-        Cratus.config.user_lockout_attribute.to_s
+        Cratus.config.user_lockout_attribute.to_s,
+        Cratus.config.user_account_control_attribute.to_s
       ]
     }
   end
@@ -39,7 +40,8 @@ describe Cratus::User do
         department: ['IT'],
         samaccountname: ['foobar'],
         lockouttime: ['0'],
-        memberOf: []
+        memberOf: [],
+        useraccountcontrol: ['512']
       }
     ]
   end
@@ -53,7 +55,8 @@ describe Cratus::User do
         department: ['IT'],
         samaccountname: ['foobar'],
         lockouttime: ['0'],
-        memberOf: []
+        memberOf: [],
+        useraccountcontrol: ['512']
       },
       {
         dn: ['samaccountname=binbaz,ou=users,dc=example,dc=com'],
@@ -62,7 +65,8 @@ describe Cratus::User do
         department: ['IT'],
         samaccountname: ['binbaz'],
         lockouttime: ['0'],
-        memberOf: []
+        memberOf: [],
+        useraccountcontrol: ['512']
       }
     ]
   end


### PR DESCRIPTION
The title should be fairly self-explanatory. I've added functionality to allow unlocking users, checking if they are enabled (or disabled), and enabling/disabling them. Also updated the README and made existing tests work. Probably wouldn't hurt to add additional test coverage on these changes, but they are pretty simple wrappers on `Cratus::LDAP.replace_attribute` which is already tested.